### PR TITLE
Fix of #26

### DIFF
--- a/src/BSON.jl
+++ b/src/BSON.jl
@@ -5,7 +5,21 @@ export bson
 
 using Core: SimpleVector, TypeName
 
-const BSONDict = Dict{Symbol,Any}
+struct BSONDict <: AbstractDict{Symbol,Any}
+  d::Dict{Symbol,Any}
+end
+# implement some of the needed Dict methods
+BSONDict(v) = BSONDict(Dict{Symbol,Any}(v))
+BSONDict(v...) = BSONDict(Dict{Symbol,Any}(v...))
+Base.length(bd::BSONDict) = length(bd.d)
+Base.isempty(bd::BSONDict) = length(bd.d)==0
+Base.setindex!(bd::BSONDict, v, k) = setindex!(bd.d, v, k)
+Base.getindex(bd::BSONDict, k) = getindex(bd.d, k)
+Base.iterate(bd::BSONDict) = iterate(bd.d)
+Base.iterate(bd::BSONDict, i) = iterate(bd.d, i)
+Base.get(bd::BSONDict, k, d) = get(bd.d, k, d)
+Base.delete!(bd::BSONDict, k) = delete!(bd.d, k)
+
 const BSONArray = Vector{Any}
 const Primitive = Union{Nothing,Bool,Int32,Int64,Float64,String,Vector{UInt8},BSONDict,BSONArray}
 

--- a/src/extensions.jl
+++ b/src/extensions.jl
@@ -1,5 +1,3 @@
-lower(x::Dict{Symbol}) = BSONDict(x)
-
 # Basic Types
 
 ismutable(::Type{Symbol}) = false


### PR DESCRIPTION
This is an attempt to fix #26 by making `BSONDict` its own type.  I suspect that something like this could work, but this doesn't.  It fixes the behavior seen in #26 but the loading does not work yet.

Unfortunately, I don't have time to tinker more, but maybe someone else does?