### PR TITLE
support non-dict fileio_save args

### DIFF
--- a/src/fileio_interface.jl
+++ b/src/fileio_interface.jl
@@ -6,11 +6,11 @@ fileio_save(f, args::Pair...) = bson(f.filename, Dict(args))
 #This syntax is already in use to work with |> in FileIO
 #fileio_save(f; kws...) = bson(f.filename, Dict(kws))
 
-#function fileio_save(f, args...)
-#    @assert length(args) % 2 ==0 "Mismatch between labels and data fields"
-#    d = Dict(args[1:2:end] .=> args[2:2:end])
-#    bson(f.filename, d)
-#end
+function fileio_save(f, args...)
+    l = [Symbol("Var$(i)") for i in 1:length(args)]
+    d = Dict(l .=> args)
+    bson(f.filename, d)
+end
 
 fileio_load(f) = load(f.filename)
 


### PR DESCRIPTION
Continue #31 
The idea is quite simple: create a dummy name for each input and wrap them into a Dict. ( I didn't know BSON data should be represented by a Dict until I check this repo)

This makes `save("model.bson", model)`-kind usage works instead of
throwing MethodError.

An alternative is to print more descriptive error message than 
```julia
julia > FileIO.save("mymodel.bson", model)
Error encountered while saving "mymodel.bson".
Fatal error:
ERROR: MethodError: no method matching fileio_save(::File{DataFormat{:BSON}}, ::Chain{Tuple{Dense{typeof(relu),TrackedArray{…,Array{Float32,2}},TrackedArray{…,Array{Float32,1}}},Dense{typeof(identity),TrackedArray{…,Array{Float32,2}},TrackedArray{…,Array{Float32,1}}},typeof(softmax)}})
Closest candidates are:
  fileio_save(::Any, ::AbstractDict) at /home/math/jc/.julia/packages/BSON/XPZLD/src/fileio_interface.jl:3
  fileio_save(::Any, ::Pair...) at /home/math/jc/.julia/packages/BSON/XPZLD/src/fileio_interface.jl:4
``` 