### PR TITLE
Allow saving IdDict

### DIFF
--- a/src/extensions.jl
+++ b/src/extensions.jl
@@ -145,11 +145,11 @@ tags[:jl_bottom_type] = d -> Union{}
 
 # Base data structures
 
-structdata(d::AbstractDict) = Any[collect(keys(d)), collect(values(d))]
+structdata(d::Union{IdDict,Dict}) = Any[collect(keys(d)), collect(values(d))]
 
-initstruct(D::Type{<:AbstractDict}) = D()
+initstruct(D::Type{<:Union{IdDict,Dict}}) = D()
 
-function newstruct!(d::AbstractDict, ks, vs)
+function newstruct!(d::Union{IdDict,Dict}, ks, vs)
   for (k, v) in zip(ks, vs)
     d[k] = v
   end

--- a/src/extensions.jl
+++ b/src/extensions.jl
@@ -145,11 +145,11 @@ tags[:jl_bottom_type] = d -> Union{}
 
 # Base data structures
 
-structdata(d::Dict) = Any[collect(keys(d)), collect(values(d))]
+structdata(d::AbstractDict) = Any[collect(keys(d)), collect(values(d))]
 
-initstruct(D::Type{<:Dict}) = D()
+initstruct(D::Type{<:AbstractDict}) = D()
 
-function newstruct!(d::Dict, ks, vs)
+function newstruct!(d::AbstractDict, ks, vs)
   for (k, v) in zip(ks, vs)
     d[k] = v
   end


### PR DESCRIPTION
Another approach to solve the issues in saving parameters from Flux/ Zygote directly, for structures based on using `IdDict`. In the basic saving and loading test, things seem to work fine, but I would like to know if this would break any assumptions.

MWE:
```Julia
julia> d = IdDict(:a => 1, :b => rand(3))
IdDict{Symbol,Any} with 2 entries:
  :a => 1
  :b => [0.819137, 0.668358, 0.611674]

# without the PR:
julia> @save "d.dict" d
# error: Access to undefined reference
```

cc @MikeInnes