### PR TITLE
Alternative Fix of #26

### DIFF
--- a/src/extensions.jl
+++ b/src/extensions.jl
@@ -1,4 +1,5 @@
 lower(x::Dict{Symbol}) = BSONDict(x)
+lower(x::BSONDict) = BSONDict(x)
 
 # Basic Types
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,6 +41,7 @@ end
   @test roundtrip_equal(fill(S(), (1,3)))
   @test roundtrip_equal(Set([1,2,3]))
   @test roundtrip_equal(Dict("a"=>1))
+  @test roundtrip_equal(Dict(:a => 1, :b => [1, 2]))
   @test roundtrip_equal(T(()))
 end
 


### PR DESCRIPTION
Simpler fix for #26, alternative to #29. Also adds a test to verify the bug is solved, i.e. `Dict{Symbol, Any}`  in the input are not modified when writing to a file.

Though shorter, this fix may be less robust than the one proposed in #29.