### PR TITLE
Warn users of unexpected type changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Dict{Symbol,Any} with 2 entries:
 
 (Note that the top-level object in BSON is always a `Dict{Symbol,Any}`).
 
+> ⚠️ **Warning**: Saving and loading julia structures using BSON may modify types of these structures in unexpected ways (see issues), potentially leading to unexpected errors.
+
 > ⚠️ **Warning**: Loading BSON files is not safe from malicious or erroneously constructed data. Loading BSON files can cause arbitrary code to execute on your machine. Do not load files from unknown or untrusted sources.
 
 There a few utility methods for working with BSON files.


### PR DESCRIPTION
There seem to be ongoing issues with BSON changing types of saved structures (https://github.com/JuliaIO/BSON.jl/issues/84) that may lead to cryptic error messages in user code. It would be nice to have a warning in the README before this behavior is addressed in some way (either update of README or change in the code).