### PR TITLE
Fix anonymous functions in Julia 1.6

### DIFF
--- a/src/anonymous.jl
+++ b/src/anonymous.jl
@@ -25,6 +25,24 @@ end
 
 initstruct(::Type{Method}) = ccall(:jl_new_method_uninit, Ref{Method}, (Any,), Main)
 
+if VERSION < v"1.6-"
+function newstruct!(meth::Method, mod, name, file, line, sig,
+                    syms, ambig, nargs, isva, nospecialize, ast)
+  meth.module = mod
+  meth.name = name
+  meth.file = file
+  meth.line = line
+  meth.sig = sig
+  setfield!(meth, syms_fieldname, syms)
+  meth.ambig = ambig
+  meth.nospecialize = nospecialize
+  meth.nargs = nargs
+  meth.isva = isva
+  meth.source = ast
+  meth.pure = ast.pure
+  return meth
+end
+else
 function newstruct!(meth::Method, mod, name, file, line, sig,
                     syms, nargs, isva, nospecialize, ast)
   meth.module = mod
@@ -39,6 +57,7 @@ function newstruct!(meth::Method, mod, name, file, line, sig,
   meth.source = ast
   meth.pure = ast.pure
   return meth
+end
 end
 
 function structdata(t::TypeName)

--- a/src/anonymous.jl
+++ b/src/anonymous.jl
@@ -12,22 +12,27 @@ else
 const _uncompress = Base._uncompressed_ast
 end
 
+if VERSION < v"1.6-"
 structdata(meth::Method) =
   [meth.module, meth.name, meth.file, meth.line, meth.sig, getfield(meth, syms_fieldname),
    meth.ambig, meth.nargs, meth.isva, meth.nospecialize,
    _uncompress(meth, meth.source)]
+else
+structdata(meth::Method) =
+  [meth.module, meth.name, meth.file, meth.line, meth.sig, getfield(meth, syms_fieldname), 
+   meth.nargs, meth.isva, meth.nospecialize, _uncompress(meth, meth.source)]
+end
 
 initstruct(::Type{Method}) = ccall(:jl_new_method_uninit, Ref{Method}, (Any,), Main)
 
 function newstruct!(meth::Method, mod, name, file, line, sig,
-                    syms, ambig, nargs, isva, nospecialize, ast)
+                    syms, nargs, isva, nospecialize, ast)
   meth.module = mod
   meth.name = name
   meth.file = file
   meth.line = line
   meth.sig = sig
   setfield!(meth, syms_fieldname, syms)
-  meth.ambig = ambig
   meth.nospecialize = nospecialize
   meth.nargs = nargs
   meth.isva = isva


### PR DESCRIPTION
This fixes #80 by updating `Method` to reflect changes to the structure in Julia 1.6. There is already a test case where this fails, and the PR addresses that. Under the current test cases, this is the only Julia 1.6 issue that needed to be addressed.