### PR TITLE
julia 1.7: mutable field fix

### DIFF
--- a/src/anonymous.jl
+++ b/src/anonymous.jl
@@ -67,7 +67,7 @@ function structdata(t::TypeName)
      isdefined(t.mt, :kwsorter) ? t.mt.kwsorter : nothing]
   [Base.string(VERSION), t.name, t.names, primary.super, primary.parameters,
    primary.types, isdefined(primary, :instance), primary.abstract,
-   primary.mutable, primary.ninitialized, mt]
+   ismutabletype(primary), primary.ninitialized, mt]
 end
 
 # Type Names

--- a/src/write.jl
+++ b/src/write.jl
@@ -43,7 +43,7 @@ lower(x::Primitive) = x
 
 import Base: RefValue
 
-ismutable(T) = !isa(T, DataType) || T.mutable
+ismutable(T) = !isa(T, DataType) || ismutabletype(T)
 ismutable(::Type{String}) = false
 
 typeof_(x) = typeof(x)


### PR DESCRIPTION
JUlia 1.7 changed T.mutable: this field no longer exists:
```julia
julia> Int64.mutable
ERROR: type DataType has no field mutable
Stacktrace:
 [1] getproperty(x::Type, f::Symbol)
   @ Base ./Base.jl:28
 [2] top-level scope
   @ REPL[1]:1
```
Therefore, writing to bson files fails in julia 1.7/nightly.

In 1.7, there's now a function `ismutabletype`. This PR will use `Base.ismutabletype` for julia >1.7 and use `T.mutable` otherwise. This same approach is used in JLD2.jl [here](https://github.com/JuliaIO/JLD2.jl/pull/322)