### PR TITLE
Fix all but one 1.7 issues

### DIFF
--- a/src/anonymous.jl
+++ b/src/anonymous.jl
@@ -67,7 +67,7 @@ function structdata(t::TypeName)
      isdefined(t.mt, :kwsorter) ? t.mt.kwsorter : nothing]
   [Base.string(VERSION), t.name, t.names, primary.super, primary.parameters,
    primary.types, isdefined(primary, :instance), primary.abstract,
-   primary.mutable, primary.ninitialized, mt]
+   ismutabletype(primary), primary.ninitialized, mt]
 end
 
 # Type Names

--- a/src/anonymous.jl
+++ b/src/anonymous.jl
@@ -19,7 +19,7 @@ structdata(meth::Method) =
    _uncompress(meth, meth.source)]
 else
 structdata(meth::Method) =
-  [meth.module, meth.name, meth.file, meth.line, meth.sig, getfield(meth, syms_fieldname), 
+  [meth.module, meth.name, meth.file, meth.line, meth.sig, getfield(meth, syms_fieldname),
    meth.nargs, meth.isva, meth.nospecialize, _uncompress(meth, meth.source)]
 end
 
@@ -66,7 +66,7 @@ function structdata(t::TypeName)
     [t.mt.name, collect(Base.MethodList(t.mt)), t.mt.max_args,
      isdefined(t.mt, :kwsorter) ? t.mt.kwsorter : nothing]
   [Base.string(VERSION), t.name, t.names, primary.super, primary.parameters,
-   primary.types, isdefined(primary, :instance), primary.abstract,
+   primary.types, isdefined(primary, :instance), isabstracttype(primary),
    ismutabletype(primary), primary.ninitialized, mt]
 end
 

--- a/src/extensions.jl
+++ b/src/extensions.jl
@@ -93,10 +93,8 @@ tags[:array] = d ->
 
 # Structs
 
-isprimitive(T) = fieldcount(T) == 0 && T.size > 0
-
-structdata(x) = isprimitive(typeof(x)) ? reinterpret_(UInt8, [x]) :
-    Any[getfield(x, f) for f in fieldnames(typeof(x))]
+structdata(x) = isprimitivetype(typeof(x)) ? reinterpret_(UInt8, [x]) :
+    Any[getfield(x,f) for f in fieldnames(typeof(x)) if isdefined(x, f)]
 
 function lower(x)
   BSONDict(:tag => "struct", :type => typeof(x), :data => structdata(x))
@@ -139,7 +137,7 @@ end
 newprimitive(T, data) = reinterpret_(T, data)[1]
 
 tags[:struct] = d ->
-  isprimitive(d[:type]) ?
+  isprimitivetype(d[:type]) ?
     newprimitive(d[:type], d[:data]) :
     newstruct(d[:type], d[:data]...)
 

--- a/src/write.jl
+++ b/src/write.jl
@@ -43,7 +43,7 @@ lower(x::Primitive) = x
 
 import Base: RefValue
 
-ismutable(T) = !isa(T, DataType) || T.mutable
+ismutable(T) = !isa(T, DataType) || ismutabletype(T)
 ismutable(::Type{String}) = false
 
 typeof_(x) = typeof(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ end
 
 # avoid hitting bug where
 # Dict{Symbol,T} -> Dict{Symbol,Any}
-function roundtrip_equal(x::Dict{Symbol}) 
+function roundtrip_equal(x::Dict{Symbol})
   y = BSON.roundtrip(x)
   y isa Dict{Symbol} && y == x
 end
@@ -82,15 +82,19 @@ end
 
 @testset "Anonymous Functions" begin
   f = x -> x+1
-  f2 = BSON.roundtrip(f)
-  @test f2(5) == f(5)
-  @test typeof(f2) !== typeof(f)
+  if VERSION < v"1.7-"
+    f2 = BSON.roundtrip(f)
+    @test f2(5) == f(5)
+    @test typeof(f2) !== typeof(f)
 
-  chicken_tikka_masala(y) = x -> x+y
-  f = chicken_tikka_masala(5)
-  f2 = BSON.roundtrip(f)
-  @test f2(6) == f(6)
-  @test typeof(f2) !== typeof(f)
+    chicken_tikka_masala(y) = x -> x+y
+    f = chicken_tikka_masala(5)
+    f2 = BSON.roundtrip(f)
+    @test f2(6) == f(6)
+    @test typeof(f2) !== typeof(f)
+  else
+    @test_throws ErrorException f2 = BSON.roundtrip(f)
+  end
 end
 
 @testset "Int Literals in Type Params #41" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,11 @@ end
 
 struct S end
 
+struct Bar
+  a
+  Bar() = new()
+end
+
 module A
   using DataFrames, BSON
   d = DataFrame(a = 1:10, b = rand(10))
@@ -39,6 +44,22 @@ end
   @test roundtrip_equal("b")
   @test roundtrip_equal([1,"b"])
   @test roundtrip_equal(Tuple)
+  @test roundtrip_equal(Tuple{Int, Float64})
+  @test roundtrip_equal(Vararg{Any})
+end
+
+@testset "Undefined References" begin
+  # from Issue #3
+  d = Dict(:a => 1, :b => Dict(:c => 3, :d => Dict("e" => 5)))
+  @test roundtrip_equal(d)
+
+  # from Issue #43
+  x = Array{String, 1}(undef, 5)
+  x[1] = "a"
+  x[4] = "d"
+  @test_broken roundtrip_equal(Dict(:x => x))
+
+  @test roundtrip_equal(Bar())
 end
 
 @testset "Complex Types" begin


### PR DESCRIPTION
This builds on PR #99 (i.e. it is branched from there) and fixes some more Julia 1.7 issues.  It does not fix the issue with reconstructing anonymous functions.  I think this is what PR #102 is about, however, that one did not get Jameson's blessing and I'm not sure what he meant in his comment https://github.com/JuliaIO/BSON.jl/pull/102#issuecomment-889257222.

If resolving that issue takes a long time, it could be a possibility to merge this PR and get the last 5% sorted in another PR (instead of having a non-functioning BSON in Julia 1.7)

This PR seems to work for what I need on Julia 1.7.  So even if it is not merged, it maybe of use to others...