### PR TITLE
try finding module from loaded modules

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BSON"
 uuid = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"
-version = "0.3.6"
+version = "0.3.7"
 
 [compat]
 julia = "0.7, 1"

--- a/src/extensions.jl
+++ b/src/extensions.jl
@@ -18,7 +18,20 @@ tags[:svec] = d -> Core.svec(d[:data]...)
 
 ref(path::Symbol...) = BSONDict(:tag => "ref", :path => Base.string.([path...]))
 
-resolve(fs, init) = reduce((m, f) -> getfield(m, Symbol(f)), fs; init = init)
+function _find_module(x)
+    pkgid = findfirst(p->p[1].name == x, (k=>v for (k, v) in Base.loaded_modules))
+    return isnothing(pkgid) ? nothing : Base.loaded_modules[pkgid]
+end
+
+function resolve(fs, init)
+    ff = first(fs)
+    m = _find_module(ff)
+    if !isnothing(m)
+        init = m
+        fs = @view fs[2:end]
+    end
+    return reduce((m, f) -> getfield(m, Symbol(f)), fs; init = init)
+end
 
 tags[:ref] = (d, init) -> resolve(d[:path], init)
 

--- a/src/extensions.jl
+++ b/src/extensions.jl
@@ -19,8 +19,10 @@ tags[:svec] = d -> Core.svec(d[:data]...)
 ref(path::Symbol...) = BSONDict(:tag => "ref", :path => Base.string.([path...]))
 
 function _find_module(x)
-    pkgid = findfirst(p->p[1].name == x, (k=>v for (k, v) in Base.loaded_modules))
-    return isnothing(pkgid) ? nothing : Base.loaded_modules[pkgid]
+    for (k, v) in Base.loaded_modules
+        k.name == x && return v
+    end
+    return nothing
 end
 
 function resolve(fs, init)

--- a/src/extensions.jl
+++ b/src/extensions.jl
@@ -28,7 +28,7 @@ end
 function resolve(fs, init)
     ff = first(fs)
     m = _find_module(ff)
-    if !isnothing(m)
+    if m !== nothing
         init = m
         fs = @view fs[2:end]
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,7 +31,9 @@ end
 module A
   using DataFrames, BSON
   d = DataFrame(a = 1:10, b = rand(10))
+  a = DataFrames.PooledArrays.PooledArray(["a" "b"; "c" "d"])
   bson("test_25_dataframe.bson", Dict(:d=>d))
+  bson("test_26_module_in_module.bson", Dict(:a=>a))
 end
 
 struct NoInit
@@ -154,6 +156,11 @@ end
 @testset "Namespace other than Main #25" begin
   @test BSON.load("test_25_dataframe.bson", A)[:d] == A.d
   rm("test_25_dataframe.bson")
+end
+
+@testset "Module with module import" begin
+  @test BSON.load(joinpath(@__DIR__, "test_26_module_in_module.bson"))[:a] == A.a
+  rm("test_26_module_in_module.bson")
 end
 
 end


### PR DESCRIPTION
Solve the issue mentioned in #119 without needed to change the saved format. This would try to treat the first name in `resolve` as module name and look up `Base.loaded_modules`. If anything matched, use the matched module as `init` for `resolve`