### PR TITLE
Fix anonymous method serialization for Julia v1.10

### DIFF
--- a/src/anonymous.jl
+++ b/src/anonymous.jl
@@ -42,7 +42,7 @@ function newstruct!(meth::Method, mod, name, file, line, sig,
   meth.pure = ast.pure
   return meth
 end
-else
+elseif VERSION < v"1.10-"
 function newstruct!(meth::Method, mod, name, file, line, sig,
                     syms, nargs, isva, nospecialize, ast)
   meth.module = mod
@@ -56,6 +56,22 @@ function newstruct!(meth::Method, mod, name, file, line, sig,
   meth.isva = isva
   meth.source = ast
   meth.pure = ast.pure
+  return meth
+end
+else
+function newstruct!(meth::Method, mod, name, file, line, sig,
+                    syms, nargs, isva, nospecialize, ast)
+  meth.module = mod
+  meth.name = name
+  meth.file = file
+  meth.line = line
+  meth.sig = sig
+  setfield!(meth, syms_fieldname, syms)
+  meth.nospecialize = nospecialize
+  meth.nargs = nargs
+  meth.isva = isva
+  meth.source = ast
+  meth.purity = ast.purity
   return meth
 end
 end
@@ -148,7 +164,7 @@ else
       mtname, defs, maxa, kwsorter = mt
       mt = ccall(:jl_new_method_table, Any, (Any, Any), name, tn.module)
       mt.name = mtname
-      mt.max_args = maxa
+      @atomic mt.max_args = maxa
       ccall(:jl_set_nth_field, Cvoid, (Any, Csize_t, Any), tn, Base.fieldindex(Core.TypeName, :mt)-1, mt)
       for def in defs
         isdefined(def, :sig) || continue

--- a/src/anonymous.jl
+++ b/src/anonymous.jl
@@ -108,7 +108,7 @@ end
 
 baremodule __deserialized_types__ end
 
-if VERSION < v"1.7-"
+@static if VERSION < v"1.7-"
   function newstruct_raw(cache, ::Type{TypeName}, d, init)
     name = raise_recursive(d[:data][2], cache, init)
     name = isdefined(__deserialized_types__, name) ? gensym() : name

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,25 @@ struct Bar
   Bar() = new()
 end
 
+mutable struct Baz
+  x
+  y
+  z
+  Baz() = new()
+end
+
+function is_field_equal(a, b, field::Symbol)
+  !isdefined(a, field) && return !isdefined(b, field)
+  !isdefined(b, field) && return false
+  return getfield(a, field) == getfield(b, field)
+end
+
+function Base.:(==)(a::Baz, b::Baz)
+  return is_field_equal(a, b, :x) &&
+         is_field_equal(a, b, :y) &&
+         is_field_equal(a, b, :z)
+end
+
 module A
   using DataFrames, BSON
   d = DataFrame(a = 1:10, b = rand(10))
@@ -72,6 +91,10 @@ end
   @test_broken roundtrip_equal(Dict(:x => x))
 
   @test roundtrip_equal(Bar())
+
+  o = Baz()
+  o.y = 1
+  @test roundtrip_equal(o)
 end
 
 @testset "Complex Types" begin


### PR DESCRIPTION
This appears to be enough to resolve https://github.com/JuliaIO/BSON.jl/issues/124:
```julia
julia> versioninfo()
Julia Version 1.10.0
Commit 3120989f39b (2023-12-25 18:01 UTC)
...
julia> using BSON

julia> f = x -> x+1
       #1 (generic function with 1 method)
#1 (generic function with 1 method)

julia> f2 = BSON.roundtrip(f) # ok 
#1 (generic function with 1 method)
```

fwiw, I have not done a careful review of the serialization logic - this is just an effort to patch the conspicuous regressions