### PR TITLE
Fix `@atomic` usage on 1.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
         version:
           - '1.0' # Replace this with the minimum Julia version that your package supports.
           - '1'   # automatically expands to the latest stable 1.x release of Julia
+          - '1.6'
+          - '1.9'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/src/anonymous.jl
+++ b/src/anonymous.jl
@@ -140,6 +140,39 @@ baremodule __deserialized_types__ end
     end
     return tn
   end
+else @static if VERSION < v"1.10-"
+  function newstruct_raw(cache, ::Type{TypeName}, d, init)
+    name = raise_recursive(d[:data][2], cache, init)
+    name = isdefined(__deserialized_types__, name) ? gensym() : name
+    tn = ccall(:jl_new_typename_in, Ref{Core.TypeName}, (Any, Any),
+               name, __deserialized_types__)
+    cache[d] = tn
+    names, super, parameters, types, has_instance, atomicfields,
+      abstr, mutabl, ninitialized = map(x -> raise_recursive(x, cache, init), d[:data][3:end-1])
+    ndt = ccall(:jl_new_datatype, Any, (Any, Any, Any, Any, Any, Any, Any, Cint, Cint, Cint),
+                tn, tn.module, super, parameters, names, types, atomicfields,
+                abstr, mutabl, ninitialized)
+    # ty = tn.wrapper = ndt.name.wrapper
+    ty = ndt.name.wrapper
+    ccall(:jl_set_const, Cvoid, (Any, Any, Any), tn.module, tn.name, ty)
+    if has_instance && !isdefined(ty, :instance)
+      # use setfield! directly to avoid `fieldtype` lowering expecting to see a Singleton object already on ty
+      Core.setfield!(ty, :instance, ccall(:jl_new_struct, Any, (Any, Any...), ty))
+    end
+    mt = raise_recursive(d[:data][end], cache, init)
+    if mt != nothing
+      mtname, defs, maxa, kwsorter = mt
+      mt = ccall(:jl_new_method_table, Any, (Any, Any), name, tn.module)
+      mt.name = mtname
+      mt.max_args = maxa
+      ccall(:jl_set_nth_field, Cvoid, (Any, Csize_t, Any), tn, Base.fieldindex(Core.TypeName, :mt)-1, mt)
+      for def in defs
+        isdefined(def, :sig) || continue
+        ccall(:jl_method_table_insert, Cvoid, (Any, Any, Ptr{Cvoid}), mt, def, C_NULL)
+      end
+    end
+    return tn
+  end
 else
   function newstruct_raw(cache, ::Type{TypeName}, d, init)
     name = raise_recursive(d[:data][2], cache, init)
@@ -173,6 +206,7 @@ else
     end
     return tn
   end
+end
 end
 
 # Function Types


### PR DESCRIPTION
Fixes a regression from #125 

This also adds 1.9 to the CI since apparently that was missing.