### PR TITLE
fix padding error

### DIFF
--- a/src/extensions.jl
+++ b/src/extensions.jl
@@ -90,8 +90,17 @@ tags[:unionall] = d -> UnionAll(d[:var], d[:body])
 lower(x::Vector{Any}) = copy(x)
 lower(x::Vector{UInt8}) = x
 
-reinterpret_(::Type{T}, x) where T =
-    T[_x for _x in reinterpret(T, x)]
+function reinterpret_(::Type{T}, x) where T
+  r = reinterpret(T, x)
+  if r isa Base.ReinterpretArray && !(r.readable)
+    # type mapping was successful, but the array is not readable due to padding
+    # in that case make r a type-cast view of the original array
+    # the data might not be restorable on a different machine with different padding or with a different version of Julia
+    @warn "storing structure with padding, data might not be restorable"
+    r = unsafe_wrap(Vector{T}, Ptr{T}(pointer(x)), sizeof(x))
+  end
+  T[_x for _x in r]
+end
 
 function lower(x::Array)
   ndims(x) == 1 && !isbitstype(eltype(x)) && return Any[x...]

--- a/src/extensions.jl
+++ b/src/extensions.jl
@@ -90,16 +90,25 @@ tags[:unionall] = d -> UnionAll(d[:var], d[:body])
 lower(x::Vector{Any}) = copy(x)
 lower(x::Vector{UInt8}) = x
 
+const WARN_PADDING = Ref(true)
+
 function reinterpret_(::Type{T}, x) where T
   r = reinterpret(T, x)
   if r isa Base.ReinterpretArray && !(r.readable)
     # type mapping was successful, but the array is not readable due to padding
-    # in that case make r a type-cast view of the original array
+    # in that case make use unsafe_wrap() to map the data 
     # the data might not be restorable on a different machine with different padding or with a different version of Julia
-    @warn "storing structure with padding, data might not be restorable"
-    r = unsafe_wrap(Vector{T}, Ptr{T}(pointer(x)), sizeof(x))
+    WARN_PADDING[] && @warn """
+    Storing structure with padding, data might not be restorable.\n
+    To suppress this warning, set BSON.WARN_PADDING[] = false.
+    """
+    GC.@preserve x begin
+      a = unsafe_wrap(Vector{T}, Ptr{T}(pointer(x)), sizeof(x) ÷ sizeof(T))
+      T[_x for _x in a]
+    end
+  else
+      T[_x for _x in r]
   end
-  T[_x for _x in r]
 end
 
 function lower(x::Array)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -186,4 +186,14 @@ end
   rm("test_26_module_in_module.bson")
 end
 
+@testset "Arrays of mixed-type tuples" begin
+  a = [(1, true), (2, false)]
+  @test roundtrip_equal(a)
+  @test_logs (:warn, r"Storing structure") BSON.roundtrip(a)
+  x = BSON.WARN_PADDING[]
+  BSON.WARN_PADDING[] = false
+  @test_logs BSON.roundtrip(a)
+  BSON.WARN_PADDING[] = x
+end
+
 end


### PR DESCRIPTION
This PR addresses #121 
Not sure, what a good way of warning could be. Currently I spit out a warning every time, which is probably not the best idea for the final version.
[Mikmoore's comments on discourse](https://discourse.julialang.org/t/reinterpret-vector-of-mixed-type-tuples/127230/3) were very helpful for finding this solution.